### PR TITLE
feat: add reset button

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,11 +1,13 @@
 import Graph from './layout/Graph'
 import SearchBar from './components/SearchBar'
 import Notif from './components/Notif'
+import ResetButton from './components/ResetButton'
 
 const App = () => {
   return (
     <>
       <SearchBar />
+      <ResetButton />
       <Graph />
       <Notif />
     </>

--- a/src/components/ResetButton/ResetButton.jsx
+++ b/src/components/ResetButton/ResetButton.jsx
@@ -1,0 +1,14 @@
+import useData from "../../store/useData";
+import { Affix, Button } from "@mantine/core";
+
+const ResetButton = () => {
+  const { resetGraph } = useData();
+
+  return (
+    <Affix top={20} right={20}>
+      <Button color="red" onClick={resetGraph}>Reset</Button>
+    </Affix>
+  );
+};
+
+export default ResetButton;

--- a/src/components/ResetButton/index.jsx
+++ b/src/components/ResetButton/index.jsx
@@ -1,0 +1,3 @@
+import ResetButton from './ResetButton';
+
+export default ResetButton;

--- a/src/services/wikidata.js
+++ b/src/services/wikidata.js
@@ -49,6 +49,7 @@ const searchArticles = async (search, signal) => {
   + '&action=wbsearchentities'
   + '&type=item'
   + '&continue=0'
+  + '&limit=8'
   + `&search=${search}`
   const res = await axios.get(url, { signal, headers })
   return res.data.search

--- a/src/store/useData.js
+++ b/src/store/useData.js
@@ -72,6 +72,14 @@ const useData = create((set, get) => ({
       set({ fetchState: error.message })
     }
   },
+  resetGraph: () => {
+    set({ 
+      graphData: { nodes: [], links: [] },
+      expandedItems: [],
+      nodeMap: new Map(),
+      fetchState: null
+    })
+  }
 }))
 
 export default useData


### PR DESCRIPTION
This pull request introduces a new button in the user interface that allows users to reset the graph to its initial state. This functionality is useful for cases where the user wants to reset the network after performing several interactions or modifications.

Changes :

New Reset Button:

A reset button has been added to the user interface.
The button is stylized to integrate with the current design of the application.

Reset Functionality:
Clicking the button resets the state values ​​to their initial state.

Component Status Updates:
Added a resetGraph method in useData.