### PR TITLE
Make Parent and Children Items Share the Same Hue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,8 @@
         "@mantine/core": "^7.8.1",
         "@mantine/hooks": "^7.8.1",
         "axios": "^1.6.8",
+        "color": "^4.2.3",
+        "randomcolor": "^0.6.2",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-force-graph-2d": "^1.25.4",
@@ -1709,6 +1711,18 @@
         "node": ">=6"
       }
     },
+    "node_modules/color": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
+      "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
+      "dependencies": {
+        "color-convert": "^2.0.1",
+        "color-string": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=12.5.0"
+      }
+    },
     "node_modules/color-convert": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -1721,8 +1735,32 @@
     "node_modules/color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-      "dev": true
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
+    },
+    "node_modules/color-string": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
+      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+      "dependencies": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
+    },
+    "node_modules/color/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -3148,6 +3186,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-arrayish": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
+      "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
+    },
     "node_modules/is-async-function": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-async-function/-/is-async-function-2.0.0.tgz",
@@ -4029,6 +4072,11 @@
         }
       ]
     },
+    "node_modules/randomcolor": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/randomcolor/-/randomcolor-0.6.2.tgz",
+      "integrity": "sha512-Mn6TbyYpFgwFuQ8KJKqf3bqqY9O1y37/0jgSK/61PUxV4QfIMv0+K2ioq8DfOjkBslcjwSzRfIDEXfzA9aCx7A=="
+    },
     "node_modules/react": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
@@ -4474,6 +4522,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/simple-swizzle": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+      "integrity": "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==",
+      "dependencies": {
+        "is-arrayish": "^0.3.1"
       }
     },
     "node_modules/source-map-js": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
     "@mantine/core": "^7.8.1",
     "@mantine/hooks": "^7.8.1",
     "axios": "^1.6.8",
+    "color": "^4.2.3",
+    "randomcolor": "^0.6.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-force-graph-2d": "^1.25.4",

--- a/src/layout/Graph/Graph.jsx
+++ b/src/layout/Graph/Graph.jsx
@@ -16,7 +16,7 @@ const Graph = () => {
     expandItem(node)
   }
 
-  const assignNodeColor = ({ isProperty }) => isProperty ? '#bbbbbb' : '#707070'
+  const assignNodeColor = ({ isProperty, __color }) => isProperty ? '#bbbbbb' : __color
 
   const assignNodeVal = ({ isProperty }) => isProperty ? 0.25 : 1.5
 

--- a/src/store/useData.js
+++ b/src/store/useData.js
@@ -24,9 +24,9 @@ const useData = create((set, get) => ({
       if (expandedItems.includes(root)) {
         return
       }
-      const rootColor = randomColor({ luminosity: 'dark'})
+      const childColor = randomColor({hue:'random', luminosity: 'light'})
+      const rootColor = Color(childColor).darken(0.5).hex()
       root.__color = rootColor
-      const childColor = Color(rootColor).lighten(0.7).hex()
       expandedItems.push(root)
       state.graphData.nodes.forEach(node => nodes.push(node))
       state.graphData.links.forEach(link => links.push(link))
@@ -55,6 +55,14 @@ const useData = create((set, get) => ({
           item.__color = childColor
           nodes.push(item)
           nodeMap.set(item.id, item)
+        } else {
+          if(!(expandedItems.some(expandedItem => expandedItem.id === item.id))) {
+            const existingNode = state.nodeMap.get(item.id)
+            if(existingNode) {
+              const combinedColor = Color(existingNode.__color).mix(Color(childColor), 0.5).hex()
+              existingNode.__color = combinedColor
+            }
+          }
         }
 
         links.push({

--- a/src/store/useData.js
+++ b/src/store/useData.js
@@ -1,5 +1,7 @@
 import { create } from "zustand"
 import wikidata from "../services/wikidata"
+import randomColor from "randomcolor"
+import Color from "color"
 
 const useData = create((set, get) => ({
   graphData: {
@@ -22,6 +24,11 @@ const useData = create((set, get) => ({
       if (expandedItems.includes(root)) {
         return
       }
+      const rootColor = randomColor({ luminosity: 'dark'})
+      root.__color = rootColor
+      const childColor = Color(rootColor).lighten(0.7).hex()
+      // console.log(childColor)
+      // console.log(root)
       expandedItems.push(root)
       state.graphData.nodes.forEach(node => nodes.push(node))
       state.graphData.links.forEach(link => links.push(link))
@@ -47,6 +54,7 @@ const useData = create((set, get) => ({
         }
 
         if (!(nodeMap.has(item.id))) {
+          item.__color = childColor
           nodes.push(item)
           nodeMap.set(item.id, item)
         }

--- a/src/store/useData.js
+++ b/src/store/useData.js
@@ -27,8 +27,6 @@ const useData = create((set, get) => ({
       const rootColor = randomColor({ luminosity: 'dark'})
       root.__color = rootColor
       const childColor = Color(rootColor).lighten(0.7).hex()
-      // console.log(childColor)
-      // console.log(root)
       expandedItems.push(root)
       state.graphData.nodes.forEach(node => nodes.push(node))
       state.graphData.links.forEach(link => links.push(link))


### PR DESCRIPTION
**This pull request makes the following request**
- Fix issue #2 


**Checklist**
- [x] Parent items must have prominent shades compared to their children.
- [x] Children items that become parents (either by click or search) must get a new color, and its children must share said color's hue.
- [x] Children shared by different parents had the mix of the parent's hues.

**Details**
- For random colors use randomcolor library  [RandomColor Js](https://github.com/davidmerfield/randomColor)
- To highlight the parents use color  [ColorJs](https://github.com/Qix-/color)
- Use nodeMap for find another parent of the child to mix colors
